### PR TITLE
Patch/funcarg fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sunbather"
-version = "1.0.0a1"
+version = "1.0.1"
 # dynamic = ["version"]
 dependencies = [
   "numpy >= 1.24.3, <3",
@@ -16,7 +16,7 @@ dependencies = [
 ]
 requires-python = ">= 3.9"
 authors = [
-  {name = "Dion Linssen", email = "d.c.linssen@uva.nl"},
+  {name = "Dion Linssen", email = "dionlinssen@hotmail.com"},
   {name = "Antonija Oklopčić", email = "a.oklopcic@uva.nl"},
 ]
 description = "sunbather"

--- a/src/sunbather/construct_parker.py
+++ b/src/sunbather/construct_parker.py
@@ -794,8 +794,9 @@ def run(
     zelem : dict
         Abundance scale factor for specific elements, e.g. {"Fe": 10, "He": 0.01}.
         Can also be used to toggle elements off, e.g. {"Ca": 0}.
-        Combines with "z" keyword. Using this results in running p_winds
-        in an iterative scheme where Cloudy updates the mu parameter.
+        Combines with "z" keyword. Beware that this is multiplicative!
+        Using this results in running p_winds in an iterative scheme where Cloudy
+        updates the mu parameter.
     mu_conv : float
         Convergence threshold expressed as the relative change in mu_bar
         between iterations.  Will only be used if fraction_hydrogen is None, in
@@ -820,6 +821,10 @@ def run(
         p-winds implementation.
     cores : int
         Number of parallel processes to spawn (i.e., number of CPU cores).
+        Note that on most platforms the multiprocessing method uses 'spawn', 
+        and this generally requires the run() call to be in a main block:
+            if __name__ == '__main__':
+                ...
     """
     if mdot is None:
         mdot = []
@@ -857,6 +862,12 @@ def run(
                 )
             )
 
+    # don't use a pool for a single core
+    if int(cores) <= 1:
+        for args in pars:
+            catch_errors_run_s(*args)
+        return
+    
     with multiprocessing.Pool(cores) as p:
         p.starmap(catch_errors_run_s, pars)
         p.close()
@@ -1224,6 +1235,7 @@ def new_argument_parser():
     composition_group.add_argument(
         "-z",
         "--metallicity",
+        dest="z",
         type=float,
         help=(
             "metallicity (=scale factor relative to solar for all elements except H "
@@ -1299,11 +1311,6 @@ def main(**kwargs):
     else:
         args = kwargs
 
-    if args.z is not None:
-        zdict = tools.get_zdict(z=args.z, zelem=args.zelem)
-    else:  # if z==None we should not pass that to the tools.get_zdict function
-        zdict = tools.get_zdict(zelem=args.zelem)
-
     if args.fraction_hydrogen is not None and (
         args.zelem != {}
         or args.mu_conv != 0.01
@@ -1349,20 +1356,21 @@ def main(**kwargs):
     )
 
     run(
-        args.plname,
-        args.pdir,
-        args.cores,
-        mdot,
-        temp,
-        args.sed_name,
-        args.fraction_hydrogen,
-        zdict,
-        args.mu_conv,
-        args.mu_maxit,
-        args.overwrite,
-        args.verbose,
-        args.avoid_pwinds_mubar,
-        args.no_tidal,
+        plname=args.plname,
+        pdir=args.pdir,
+        mdot=mdot,
+        temp=temp,
+        sed_name=args.sed_name,
+        fraction_hydrogen=args.fraction_hydrogen,
+        z=args.z,
+        zelem=args.zelem,
+        mu_conv=args.mu_conv,
+        mu_maxit=args.mu_maxit,
+        overwrite=args.overwrite,
+        verbose=args.verbose,
+        avoid_pwinds_mubar=args.avoid_pwinds_mubar,
+        no_tidal=args.no_tidal,
+        cores=args.cores,
     )
 
     print(

--- a/src/sunbather/construct_parker.py
+++ b/src/sunbather/construct_parker.py
@@ -762,6 +762,33 @@ def run(
     cores=1,
 ):
     """
+    Calculates isothermal Parker wind models.
+
+    Parameters
+    ----------
+    plname : str
+        Planet name (must have parameters stored in
+        $SUNBATHER_PROJECT_PATH/planets.txt).
+    pdir : str
+        Directory as $SUNBATHER_PROJECT_PATH/parker_profiles/*plname*/*pdir*/
+        where the isothermal parker wind density and velocity profiles are saved.
+        Different folders may exist there for a given planet, to separate for
+        example profiles with different assumptions such as stellar
+        SED/semi-major axis/composition.
+    mdot : numeric, list, or numpy array
+        log of the mass-loss rate in units of g s-1.
+    temp : numeric, list, or numpy array
+        Temperature in units of K.
+    sed_name : str
+        Name of SED file to use. If sed_name is 'real', we use the name as
+        given in the planets.txt file, but if sed_name is something else,
+        we advice to use a separate pdir folder for this.
+    fraction_hydrogen : float or None
+        Hydrogen abundance expressed as a fraction of the total. If a value is given,
+        Parker wind profiles will be calculated using p-winds standalone with a H/He
+        composition. If None is given, Parker wind profiles will be calculated
+        using the p-winds/Cloudy iterative method and the composition is
+        specified via the zdict argument.
     z : float
         Metallicity (=scale factor relative to solar for all elements except H
         and He). Using this keyword results in running p_winds in an iterative
@@ -771,6 +798,30 @@ def run(
         Can also be used to toggle elements off, e.g. {"Ca": 0}.
         Combines with "z" keyword. Using this results in running p_winds
         in an iterative scheme where Cloudy updates the mu parameter.
+    mu_conv : float
+        Convergence threshold expressed as the relative change in mu_bar
+        between iterations.  Will only be used if fraction_hydrogen is None, in
+        which case the p-winds/Cloudy iterative method is applied.
+    mu_maxit : int
+        Maximum number of iterations for the p-winds/Cloudy iterative method. Will only
+        be used if fraction_hydrogen is None.
+    overwrite : bool
+        Whether to overwrite existing models.
+    verbose : bool
+        Whether to print diagnostics about the convergence of mu_bar.
+    avoid_pwinds_mubar : bool
+        Whether to avoid using p-winds to calculate mu_bar during the first iteration,
+        when using the p-winds/Cloudy iterative method. Will only be used if
+        fraction_hydrogen is None.
+        If True, we guess the mu_bar of the first iteration based on a
+        completely neutral atmosphere. This can be helpful in cases where
+        p-winds solver cannot find a solution, but Cloudy typically can.
+    no_tidal : bool
+        Whether to neglect tidal gravity - fourth term of Eq. 4 of Linssen et
+        al. (2024).  See also Appendix D of Vissapragada et al. (2022) for the
+        p-winds implementation.
+    cores : int
+        Number of parallel processes to spawn (i.e., number of CPU cores).
     """
     if mdot is None:
         mdot = []
@@ -798,6 +849,7 @@ def run(
                     mu_maxit,
                     overwrite,
                     verbose,
+                    avoid_pwinds_mubar,
                     no_tidal,
                 )
             )
@@ -820,6 +872,7 @@ def run_s(
     mu_maxit,
     overwrite,
     verbose,
+    avoid_pwinds_mubar,
     no_tidal,
 ):
     """
@@ -866,6 +919,11 @@ def run_s(
         Whether to overwrite existing models.
     verbose : bool
         Whether to print diagnostics about the convergence of mu_bar.
+    avoid_pwinds_mubar : bool
+        Whether to avoid using p-winds to calculate mu_bar during the first
+        iteration.  If True, we guess the mu_bar of the first iteration based
+        on a completely neutral atmosphere. This can be helpful in cases where
+        p-winds solver cannot find a solution, but Cloudy typically can.
     no_tidal : bool
         Whether to neglect tidal gravity - fourth term of Eq. 4 of Linssen et
         al. (2024).  See also Appendix D of Vissapragada et al. (2022) for the
@@ -948,7 +1006,7 @@ def run_g(
 ):
     """
     Calculates a grid of isothermal Parker wind models, by executing the
-    run() function in parallel.
+    run_s() function in parallel.
 
     Parameters
     ----------
@@ -1038,7 +1096,7 @@ def run_g(
             )
 
     with multiprocessing.Pool(cores) as p:
-        p.starmap(catch_errors_run, pars)
+        p.starmap(catch_errors_run_s, pars)
         p.close()
         p.join()
 
@@ -1287,7 +1345,7 @@ def main(**kwargs):
         1 + (args.temp_upper - args.temp_lower) // args.temp_step
     )
 
-    run_models(
+    run(
         args.plname,
         args.pdir,
         args.cores,

--- a/src/sunbather/construct_parker.py
+++ b/src/sunbather/construct_parker.py
@@ -497,7 +497,7 @@ def run_parker_with_cloudy(filename, temp, planet, zdict):
         double_tau=True,
         cosmic_rays=True,
         zdict=zdict,
-        constantT=temp,
+        constant_temp=temp,
         outfiles=[".ovr"],
     )
 

--- a/src/sunbather/construct_parker.py
+++ b/src/sunbather/construct_parker.py
@@ -750,8 +750,8 @@ def run(
     mdot=None,
     temp=None,
     sed_name="real",
-    fraction_hydrogen=0.9,
-    z=1.0,
+    fraction_hydrogen=None,
+    z=None,
     zelem=None,
     mu_conv=0.01,
     mu_maxit=7,
@@ -786,9 +786,7 @@ def run(
     fraction_hydrogen : float or None
         Hydrogen abundance expressed as a fraction of the total. If a value is given,
         Parker wind profiles will be calculated using p-winds standalone with a H/He
-        composition. If None is given, Parker wind profiles will be calculated
-        using the p-winds/Cloudy iterative method and the composition is
-        specified via the zdict argument.
+        composition.
     z : float
         Metallicity (=scale factor relative to solar for all elements except H
         and He). Using this keyword results in running p_winds in an iterative
@@ -831,6 +829,11 @@ def run(
         temp = []
     elif isinstance(temp, (int, float)):
         temp = [temp]
+    
+    if (fraction_hydrogen is None) == (z is None):
+        raise ValueError("Exactly one of `fraction_hydrogen` or `z` must be given to " \
+                         "specify the atmospheric composition, not both and not neither.")
+    # if fraction_hydrogen is given, the following zdict will simply not be used by run_s()
     zdict = tools.get_zdict(z=z, zelem=zelem)
 
     pars = []

--- a/src/sunbather/convergeT_parker.py
+++ b/src/sunbather/convergeT_parker.py
@@ -89,6 +89,44 @@ def find_close_model(parentfolder, T, Mdot, tolT=2000, tolMdot=1.0):
     return clconv
 
 
+def process_save_sp(save_sp, zdict, max_ion=6):
+    """
+    Removes turned-off elements from the requested Cloudy save species list.
+
+    Parameters
+    ----------
+    save_sp : list or str or None
+        Requested species to save. Passing "all" includes all available species.
+    zdict : dict
+        Dictionary with the scale factors of all elements relative to solar.
+    max_ion : int, optional
+        Maximum ionization degree when save_sp="all", by default 6.
+
+    Returns
+    -------
+    list
+        Requested species list without species whose parent element is turned off.
+    """
+    if zdict is None:
+        zdict = {}
+
+    if save_sp is None:
+        save_sp = []
+    elif save_sp == "all" or (
+        isinstance(save_sp, list) and "all" in save_sp
+    ):
+        save_sp = tools.get_specieslist(
+            exclude_elements=[element for element, zval in zdict.items() if zval == 0.0],
+            max_ion=max_ion,
+        )
+    else:
+        save_sp = [
+            sp for sp in save_sp if zdict.get(sp.split("+")[0], 1.0) != 0.0
+        ]
+
+    return save_sp
+
+
 def run_s(
     plname,
     Mdot,
@@ -159,17 +197,15 @@ def run_s(
         A list of atomic/ionic species to let Cloudy save the number density profiles
         for. Those are needed when doing radiative transfer to produce
         transmission spectra. For example, to be able to make
-        metastable helium spectra, 'He' needs to be in the save_sp list. By default [].
+        metastable helium spectra, 'He' needs to be in the save_sp list. By default all
+        species with non-zero abundance are saved.
     constantT : bool, optional
         If True, instead of sovling for a nonisothermal temperature profile,
         the Parker wind profile is ran at the isothermal value. By default False.
     maxit : int, optional
         Maximum number of iterations, by default 16.
     """
-    if save_sp is None:
-        save_sp = []
-    elif save_sp == "all":
-        save_sp = tools.get_specieslist()
+    save_sp = process_save_sp(save_sp, zdict)
 
     Mdot = f"{float(Mdot):.3f}"  # enforce this format to get standard file names.
     T = str(T)
@@ -881,11 +917,7 @@ def main(**kwargs):
 
     zdict = tools.get_zdict(z=args.z, zelem=args.zelem)
 
-    if "all" in args.save_sp:
-        args.save_sp = tools.get_specieslist(
-            exclude_elements=[sp for sp, zval in zdict.items() if zval == 0.0],
-            max_ion=args.save_sp_max_ion,
-        )
+    args.save_sp = process_save_sp(args.save_sp, zdict, max_ion=args.save_sp_max_ion)
 
     # set up the folder structure if it doesn't exist yet
     projectpath = tools.get_sunbather_project_path()

--- a/src/sunbather/convergeT_parker.py
+++ b/src/sunbather/convergeT_parker.py
@@ -262,7 +262,7 @@ def run_s(
                 cosmic_rays=True,
                 zdict=zdict,
                 comments=comments,
-                constantT=T,
+                constant_temp=T,
             )
         else:
             tools.write_Cloudy_in(
@@ -280,7 +280,7 @@ def run_s(
                 cosmic_rays=True,
                 zdict=zdict,
                 comments=comments,
-                constantT=T,
+                constant_temp=T,
                 outfiles=[".den", ".en"],
                 denspecies=save_sp,
                 selected_den_levels=True,
@@ -345,7 +345,7 @@ def run_s(
             pathTstruc, T, Mdot
         )  # find if there are any nearby models we can start from
         if startT == "constant":  # then we start with the isothermal value
-            tools.copyadd_Cloudy_in(path + "template", path + "iteration1", constantT=T)
+            tools.copyadd_Cloudy_in(path + "template", path + "iteration1", constant_temp=T)
 
         elif (
             clconv == [None, None] or startT == "free"

--- a/src/sunbather/convergeT_parker.py
+++ b/src/sunbather/convergeT_parker.py
@@ -399,15 +399,117 @@ def run(
     maxit=20,
     cores=None,
 ):
+    """
+    Solves for nonisothermal temperature profiles for one or more isothermal
+    Parker wind (density and velocity) profiles.
+
+    Parameters
+    ----------
+    plname : str
+        Planet name (must have parameters stored in
+        $SUNBATHER_PROJECT_PATH/planets.txt).
+    mdot : numeric, list, or numpy array
+        log10 of the mass-loss rate(s) in units of g s-1.
+    temp : numeric, list, or numpy array
+        Isothermal temperature(s) of the Parker wind profile(s) in units of K.
+    itno : int
+        Iteration number to start from (can only be different from 1
+        if this same model has been ran before, and then also
+        overwrite = True needs to be set). If value is 0, will automatically
+        look for the highest iteration number to start from.
+    fc : numeric
+        H/C convergence factor, see Linssen et al. (2024). A sensible value is 1.1.
+    workingdir : str
+        Directory as $SUNBATHER_PROJECT_PATH/sims/1D/planetname/*workingdir*/
+        where the temperature profile will be solved. A folder named
+        parker_*T*_*Mdot*/ will be made there.
+    sedname : str
+        Name of SED file to use. If sedname='real', we use the name as
+        given in the planets.txt file, but if sedname is something else,
+        we advice to use a separate dir folder for this.
+    overwrite : bool
+        Whether to overwrite if this simulation already exists.
+    start_temp : str
+        Either 'constant', 'free' or 'nearby'. Sets the initial
+        temperature profile guessed/used for the first iteration.
+        'constant' sets it equal to the parker wind isothermal value.
+        'free' lets Cloudy solve it, so you will get the radiative equilibrium structure.
+        'nearby' looks in the workingdir folder for previously solved
+        Parker wind profiles and starts from a converged one. Then, if no converged
+        ones are available, uses 'free' instead.
+    pdir : str
+        Directory as $SUNBATHER_PROJECT_PATH/parker_profiles/planetname/*pdir*/
+        where we take the isothermal parker wind density and velocity profiles from.
+        Different folders may exist there for a given planet, to separate for example profiles
+        with different assumptions such as stellar SED/semi-major axis/composition.
+    z : float
+        Metallicity (=scale factor relative to solar for all elements except H
+        and He).
+    zelem : dict
+        Abundance scale factor for specific elements, e.g. {"Fe": 10, "He": 0.01}.
+        Can also be used to toggle elements off, e.g. {"Ca": 0}.
+        Combines with "z" keyword. Beware that this is multiplicative!
+    altmax : int
+        Maximum altitude of the simulation in units of planet radius, by default 8.
+    save_sp : list or str
+        A list of atomic/ionic species to let Cloudy save the number density profiles
+        for. Those are needed when doing radiative transfer to produce
+        transmission spectra. For example, to be able to make
+        metastable helium spectra, 'He' needs to be in the save_sp list. Passing
+        'all' includes all species that weren't turned off.
+    constant_temp : bool
+        If True, instead of solving for a nonisothermal temperature profile,
+        the Parker wind profile is ran at the isothermal value. By default False.
+    maxit : int
+        Maximum number of iterations, by default 20.
+    cores : int or None
+        Number of parallel workers to spawn. If None, defaults to the number of CPU
+        cores as given by multiprocessing.cpu_count().
+        Note that on most platforms the multiprocessing method uses 'spawn', 
+        and this generally requires the run() call to be in a main block:
+            if __name__ == '__main__':
+                ...
+    """
     if zelem is None:
         zelem = {}
+
+    if mdot is None:
+        mdot = []
+    elif isinstance(mdot, (int, float, str)):
+        mdot = [mdot]
+    if temp is None:
+        temp = []
+    elif isinstance(temp, (int, float, str)):
+        temp = [temp]
+
     zdict = tools.get_zdict(z=z, zelem=zelem)
-    if not isinstance(mdot, list) and not isinstance(mdot, np.ndarray):
-        mdot = np.array([mdot])
-    if not isinstance(temp, list) and not isinstance(temp, np.ndarray):
-        temp = np.array([temp])
+
     if cores is None:
         cores = multiprocessing.cpu_count()
+
+    # don't use a pool for a single core
+    if int(cores) <= 1:
+        for mdot_select in mdot:
+            for temp_select in temp:
+                catch_errors_run_s(
+                    plname,
+                    mdot_select,
+                    temp_select,
+                    itno,
+                    fc,
+                    workingdir,
+                    sedname,
+                    overwrite,
+                    start_temp,
+                    pdir,
+                    zdict=zdict,
+                    altmax=altmax,
+                    save_sp=save_sp,
+                    constantT=constant_temp,
+                    maxit=maxit,
+                )
+        return
+
     with multiprocessing.Pool(processes=cores) as pool:
         workers = []
         for mdot_select in mdot:
@@ -794,9 +896,9 @@ def main(**kwargs):
     if not os.path.isdir(projectpath + "/sims/1D/" + args.plname + "/"):
         os.mkdir(projectpath + "/sims/1D/" + args.plname)
     if not os.path.isdir(
-        projectpath + "/sims/1D/" + args.plname + "/" + args.dir + "/"
+        projectpath + "/sims/1D/" + args.plname + "/" + args.workingdir + "/"
     ):
-        os.mkdir(projectpath + "/sims/1D/" + args.plname + "/" + args.dir)
+        os.mkdir(projectpath + "/sims/1D/" + args.plname + "/" + args.workingdir)
 
     if len(args.T) == 1 and len(args.Mdot) == 1:  # then we run a single model
         run_s(
@@ -897,4 +999,4 @@ def main(**kwargs):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/src/sunbather/tools.py
+++ b/src/sunbather/tools.py
@@ -1656,7 +1656,7 @@ def run_Cloudy(filename, folder=None):
     if filename.endswith(".in"):
         filename = filename[:-3]  # filename should not contain the extension
 
-    os.system(f"cd {folder} && {get_cloudy_path()}/source/cloudy.exe -p {filename}")
+    os.system(f'cd "{folder}" && "{get_cloudy_path()}/source/cloudy.exe" -p "{filename}"')
 
 
 def remove_duplicates(law, fmt):

--- a/tests/test_sunbather.py
+++ b/tests/test_sunbather.py
@@ -52,3 +52,29 @@ def test_seds():
         "Please copy /sunbather/stellar_SEDs/eps_Eri_binned.spec "
         "into $CLOUDY_PATH/data/SED/"
     )
+
+
+def test_process_save_sp_excludes_turned_off_elements():
+    """
+    Species whose parent element is turned off should not be saved.
+    """
+    from sunbather import tools, convergeT_parker
+
+    zdict = tools.get_zdict(z=0.0)
+    save_sp = convergeT_parker.process_save_sp(["H", "He", "Li", "Li+", "Mg+2"], zdict)
+
+    assert save_sp == ["H", "He"]
+
+
+def test_process_save_sp_all_excludes_zero_abundance_elements():
+    """
+    Passing save_sp='all' should skip elements with zero abundance.
+    """
+    from sunbather import tools, convergeT_parker
+
+    zdict = tools.get_zdict(z=1.0, zelem={"Li": 0.0})
+    save_sp = convergeT_parker.process_save_sp("all", zdict, max_ion=2)
+
+    assert "Li" not in save_sp
+    assert "Li+" not in save_sp
+    assert "He" in save_sp


### PR DESCRIPTION
- `avoid_pwinds_mubar` function argument now actually gets used
- Fix unintended behavior where in order to use the `z` argument in construct_parker.run(), you also had to pass `hydrogen_fraction=None` (otherwise the default of 0.9 would lead to the z value not being used). Now, the function always expects exactly one of these two arguments so the user must be explicit in which composition/run-method to use.
- Fix constant_temp variable of convergeT_parker.run() - internally it was confused with the legacy constantT variable
- Fixed some legacy CLI argparse arguments not working properly
- Added docstrings to both run() functions